### PR TITLE
Update bg2_BCS.tph

### DIFF
--- a/EET/lib/bg2_BCS.tph
+++ b/EET/lib/bg2_BCS.tph
@@ -3194,6 +3194,16 @@ THEN
     GiveItemCreate("AMUL27",Player1,1,0,0)
     Continue()
 END
+
+IF
+Global("TurnDay","AR4000",0)
+GlobalLT("Chapter","GLOBAL",20)
+Global("MoveChapter","ar4000",0)
+THEN
+RESPONSE #100
+SetGlobal("MoveChapter","ar4000",1)
+SetGlobal("Chapter","GLOBAL",20)
+END
 >>>>>>>>
 
 EXTEND_TOP ~AR4000.BCS~ ~.../AR4000-et.baf~


### PR DESCRIPTION
The OnCreation() trigger to advance chapter increment to 20 may fail if cut by mod added blocks in the script.
All PID triggering in ToB depends on correct chapter setting here. The block is an extra safety net to ensure it.