### PR TITLE
Separate out the PCU iteration of patch_dir's direct contents to omit a stray backslash.

### DIFF
--- a/EET/EET.tp2
+++ b/EET/EET.tp2
@@ -1355,12 +1355,18 @@ OUTER_SET ren_check = 0
 //conversion
 PRINT ~Please be patient during the conversion process. This may take some time...~
 
-ACTION_FOR_EACH var IN are /*bcs*/ cre /*dlg*/ eff ini itm pro spl sto vef vvc wed "" BEGIN
+ACTION_FOR_EACH var IN are /*bcs*/ cre /*dlg*/ eff ini itm pro spl sto vef vvc wed BEGIN
 	ACTION_BASH_FOR ~%patch_dir%/%var%~ ~^.+$~ BEGIN
 		COPY + ~%BASH_FOR_FILESPEC%~ ~%BASH_FOR_DIRECTORY%~
 			LPF EET_PCU_core RET ext_check END
 			SET EVAL ~%ext_check%_check~ = EVAL ~%%ext_check%_check%~ + 1
 	END
+END
+
+ACTION_BASH_FOR ~%patch_dir%~ ~^.+$~ BEGIN
+	COPY + ~%BASH_FOR_FILESPEC%~ ~%BASH_FOR_DIRECTORY%~
+		LPF EET_PCU_core RET ext_check END
+		SET EVAL ~%ext_check%_check~ = EVAL ~%%ext_check%_check%~ + 1
 END
 
 PRINT ~Conversion complete. Statistics:


### PR DESCRIPTION
WeiDU 251's case-sensitive changes break path handling with redundant backslashes in the path (at least on Linux).

~~Note that isn't enough alone to fix all v251 issues, because lacking https://github.com/WeiDUorg/weidu/issues/331 requires changes in `lib/tlk_cnt.lua` to convert the lower-case WeiDU lang folder variable to EE mixed-case folder name, but I don't think that's an EET issue and I just hope WeiDU updates to store the folder in mixed case in their own configuration before the changes sprinkle into a stable build.~~

EDIT: That is fixed.

Reported by @BettaGeorge on Discord.