### PR TITLE
WeiDU 252: Maintain case sensitivity in mod paths.

### DIFF
--- a/EET/EET.tp2
+++ b/EET/EET.tp2
@@ -94,11 +94,17 @@ PRINT ~argv[1] = %argv[1]%~
 >>>>>>>>
 
 COPY - ~weidu.conf~ ~.../weidu.conf~
-	READ_2DA_ENTRY 0 2 3 "LANGUAGE_BG2"
-	INNER_PATCH_SAVE LANGUAGE_BG2 ~%LANGUAGE_BG2%~ BEGIN
-		REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
-			TO_UPPER MATCH1
-		END ~%MATCH1%~
+	COUNT_2DA_ROWS 3 weidu_conf_rows
+	FOR (weidu_conf_row=0; weidu_conf_row < weidu_conf_rows; ++weidu_conf_row) BEGIN
+		READ_2DA_ENTRY weidu_conf_row 0 3 weidu_conf_param
+		PATCH_IF ~%weidu_conf_param%~ STR_EQ ~lang_dir~ BEGIN
+			READ_2DA_ENTRY weidu_conf_row 2 3 "LANGUAGE_BG2"
+			INNER_PATCH_SAVE LANGUAGE_BG2 ~%LANGUAGE_BG2%~ BEGIN
+				REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
+					TO_UPPER MATCH1
+				END ~%MATCH1%~
+			END
+		END
 	END
 	PATCH_PRINT ~LANGUAGE_BG2 = %LANGUAGE_BG2%~
 

--- a/EET/lib/bgee_dir.tph
+++ b/EET/lib/bgee_dir.tph
@@ -133,11 +133,17 @@ COPY + ~.../bgee_dir.txt~ ~%MOD_FOLDER%/bgee_dir.txt~ EVALUATE_BUFFER
 
 ACTION_IF FILE_EXISTS ~%bgee_dir%/weidu.conf~ BEGIN
 	COPY - ~%bgee_dir%/weidu.conf~ ~.../%bgee_dir%~
-		READ_2DA_ENTRY 0 2 3 "LANGUAGE_BG1"
-		INNER_PATCH_SAVE LANGUAGE_BG1 ~%LANGUAGE_BG1%~ BEGIN
-			REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
-				TO_UPPER MATCH1
-			END ~%MATCH1%~
+		COUNT_2DA_ROWS 3 weidu_conf_rows
+		FOR (weidu_conf_row=0; weidu_conf_row < weidu_conf_rows; ++weidu_conf_row) BEGIN
+			READ_2DA_ENTRY weidu_conf_row 0 3 weidu_conf_param
+			PATCH_IF ~%weidu_conf_param%~ STR_EQ ~lang_dir~ BEGIN
+				READ_2DA_ENTRY weidu_conf_row 2 3 "LANGUAGE_BG1"
+				INNER_PATCH_SAVE LANGUAGE_BG1 ~%LANGUAGE_BG1%~ BEGIN
+					REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
+						TO_UPPER MATCH1
+					END ~%MATCH1%~
+				END
+			END
 		END
 END ELSE ACTION_IF FILE_EXISTS ~%bgee_dir%/lang/%LANGUAGE%/dialog.tlk~ BEGIN
 	OUTER_SPRINT LANGUAGE_BG1 ~%LANGUAGE%~


### PR DESCRIPTION
WeiDU 252 introduces the option to keep case-folding in weidu.conf which breaks all EET assumptions when defined.

This is still WIP because I need to rewrite the LUA blocks as well (might just convert them to WeiDU even).