### PR TITLE
Replace Lua calls with native WeiDU equvivalents.

### DIFF
--- a/EET/EET.tp2
+++ b/EET/EET.tp2
@@ -5,7 +5,7 @@ README ~EET/lang/%LANGUAGE%/readme-EET.html~ ~EET/readme-EET.html~
 
 ALWAYS
 	ACTION_IF NOT ~%WEIDU_OS%~ STR_EQ ~win32~ BEGIN
-		ACTION_FOR_EACH file IN lua weidu BEGIN
+		ACTION_FOR_EACH file IN /*lua*/ weidu BEGIN
 			OUTER_SPRINT shell_cmd ~which %file%~
 			AT_NOW ret_val ~%shell_cmd%~
 			ACTION_IF (ret_val != 0) BEGIN
@@ -215,7 +215,7 @@ ACTION_IF ~%WEIDU_OS%~ STR_EQ ~win32~ BEGIN
 		OUTER_SPRINT arch_var ~x86_64%os_slash%~
 	END
 	PRINT ~arch_var = %arch_var%~
-	ACTION_FOR_EACH file IN lua weidu BEGIN
+	ACTION_FOR_EACH file IN /*lua*/ weidu BEGIN
 		ACTION_IF FILE_EXISTS ~%MOD_FOLDER%/bin/%WEIDU_OS%/%arch_var%%file%%exe%~ BEGIN
 			OUTER_SPRINT EVAL ~%file%~ ~%bin%%MOD_FOLDER%%os_slash%bin%os_slash%%WEIDU_OS%%os_slash%%arch_var%%file%%exe%~
 		END ELSE ACTION_IF (NOT ~%arch_var%~ STR_EQ ~~) AND (FILE_EXISTS ~%MOD_FOLDER%/bin/%WEIDU_OS%/%file%%exe%~) BEGIN

--- a/EET/EET.tp2
+++ b/EET/EET.tp2
@@ -108,19 +108,17 @@ PRINT ~argv[1] = %argv[1]%~
 >>>>>>>>
 
 COPY - ~weidu.conf~ ~.../weidu.conf~
-	COUNT_2DA_ROWS 3 weidu_conf_rows
-	FOR (weidu_conf_row=0; weidu_conf_row < weidu_conf_rows; ++weidu_conf_row) BEGIN
-		READ_2DA_ENTRY weidu_conf_row 0 3 weidu_conf_param
-		PATCH_IF ~%weidu_conf_param%~ STR_EQ ~lang_dir~ BEGIN
-			READ_2DA_ENTRY weidu_conf_row 2 3 "LANGUAGE_BG2"
-			INNER_PATCH_SAVE LANGUAGE_BG2 ~%LANGUAGE_BG2%~ BEGIN
-				REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
-					TO_UPPER MATCH1
-				END ~%MATCH1%~
-			END
-		END
+	REPLACE_EVALUATE ~\blang_dir[ %TAB%]*=[ %TAB%]*\([a-zA-Z0-9_]+\)~ BEGIN
+    	SPRINT LANGUAGE_BG2 ~%MATCH1%~
+  	END ~%MATCH0%~
+	INNER_PATCH_SAVE LANGUAGE_BG2 ~%LANGUAGE_BG2%~ BEGIN
+		REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
+			TO_UPPER MATCH1
+		END ~%MATCH1%~
 	END
-	PATCH_PRINT ~LANGUAGE_BG2 = %LANGUAGE_BG2%~
+BUT_ONLY
+
+PRINT ~LANGUAGE_BG2 = %LANGUAGE_BG2%~
 
 OUTER_SPRINT newline ~%WNL%%LNL%%MNL%%TAB% ~
 OUTER_SPRINT slash ~/~

--- a/EET/EET.tp2
+++ b/EET/EET.tp2
@@ -288,6 +288,7 @@ ACTION_IF (ret_val != 0) BEGIN
 	WARN ~Shell command failed to execute: %shell_cmd%~
 END
 
+/*
 OUTER_SPRINT shell_cmd ~%lua% %MOD_FOLDER%/lib/tlk_cnt.lua~
 PRINT ~%shell_cmd%~
 AT_NOW ret_val ~%shell_cmd%~
@@ -297,12 +298,24 @@ END
 COPY + ~%MOD_FOLDER%/temp/tlk_cnt.txt~ ~%MOD_FOLDER%/temp~
 	READ_LONG 0xa "tlk_end"
 	SET tlk_end = tlk_end + 200000 - 1
+*/
 
+COPY ~%bgee_dir%/lang/%LANGUAGE_BG1%/dialog.tlk~ ~%MOD_FOLDER%/temp/bgee-dialog.tlk~
+	READ_LONG 0xa "tlk_end"
+	SET tlk_end = tlk_end + 200000 - 1
+
+/*
 OUTER_SPRINT shell_cmd ~%lua% %MOD_FOLDER%/lib/tra_merge.lua~
 AT_NOW ret_val ~%shell_cmd%~
 ACTION_IF (ret_val != 0) BEGIN
 	WARN ~Shell command failed to execute: %shell_cmd%~
 END
+*/
+
+COPY ~%MOD_FOLDER%/temp/append.tra~ ~%MOD_FOLDER%/temp/string_set.tra~
+	APPEND_FILE ~%MOD_FOLDER%/temp/append.tra~
+	APPEND_FILE ~%MOD_FOLDER%/base/blank.tra~
+	APPEND_FILE ~%MOD_FOLDER%/temp/bgee.tra~
 
 <<<<<<<< .../string_set.tph
 PRINT ~tlk_start = %tlk_start%; tlk_end = %tlk_end%~
@@ -1181,6 +1194,7 @@ END
 ///// LUA conversion                                   \\\\\
 /////                                                  \\\\\
 
+/*
 PRINT ~~
 PRINT ~LUA conversion...~
 
@@ -1234,6 +1248,7 @@ LAM bash_log
 ACTION_IF (ret_val != 0) BEGIN
 	WARN ~Shell command failed to execute: %shell_cmd%~
 END
+*/
 
 /////                                                  \\\\\
 ///// PCU conversion                                   \\\\\
@@ -1368,7 +1383,7 @@ OUTER_SET ren_check = 0
 //conversion
 PRINT ~Please be patient during the conversion process. This may take some time...~
 
-ACTION_FOR_EACH var IN are /*bcs*/ cre /*dlg*/ eff ini itm pro spl sto vef vvc wed BEGIN
+ACTION_FOR_EACH var IN are bcs cre dlg eff ini itm pro spl sto vef vvc wed BEGIN
 	ACTION_BASH_FOR ~%patch_dir%/%var%~ ~^.+$~ BEGIN
 		COPY + ~%BASH_FOR_FILESPEC%~ ~%BASH_FOR_DIRECTORY%~
 			LPF EET_PCU_core RET ext_check END
@@ -1569,9 +1584,14 @@ COPY_LARGE + ~%MOD_FOLDER%/base/bam~ ~%biff_dir%~
 
 PRINT ~Installing BCS files...~
 
+/*
 //compile scripts
 COMPILE ~%patch_dir%/baf~
 	~%MOD_FOLDER%/compile/baf~
+*/
+
+//copy scripts over
+COPY ~%patch_dir%/bcs~ ~override~
 
 //patching BG:EE scripts
 INCLUDE ~%MOD_FOLDER%/lib/bg1_BCS.tph~
@@ -1669,6 +1689,7 @@ END
 
 PRINT ~Installing DLG files...~
 
+/*
 COPY + ~%patch_dir%/d/BPNAJIM.d~ ~%patch_dir%/d~
 	REPLACE_TEXTUALLY ~IncrementChapter("BPEND")[%newline%]*GoToStartScreen()~ ~ClearAllActions()
     ReallyForceSpellRES("K#FAMREM",Player1)
@@ -1682,6 +1703,22 @@ BUT_ONLY
 
 COMPILE ~%patch_dir%/d~
 	~%MOD_FOLDER%/compile/d~
+*/
+
+COPY ~%patch_dir%/dlg/BPNAJIM.DLG~ ~%patch_dir%/dlg~
+	DECOMPILE_AND_PATCH BEGIN
+		REPLACE_TEXTUALLY ~IncrementChapter("BPEND")[%newline%]*GoToStartScreen()~ ~ClearAllActions()
+    	ReallyForceSpellRES("K#FAMREM",Player1)
+    	ReallyForceSpellRES("K#FAMREM",Player2)
+    	ReallyForceSpellRES("K#FAMREM",Player3)
+    	ReallyForceSpellRES("K#FAMREM",Player4)
+    	ReallyForceSpellRES("K#FAMREM",Player5)
+    	ReallyForceSpellRES("K#FAMREM",Player6)
+    	StartCutScene("K#CUTBP2")~
+	END
+BUT_ONLY
+
+COPY ~%patch_dir%/dlg~ ~override~
 
 /////                                                  \\\\\
 ///// workaround for engine differences                \\\\\

--- a/EET/EET.tp2
+++ b/EET/EET.tp2
@@ -108,11 +108,17 @@ PRINT ~argv[1] = %argv[1]%~
 >>>>>>>>
 
 COPY - ~weidu.conf~ ~.../weidu.conf~
-	READ_2DA_ENTRY 0 2 3 "LANGUAGE_BG2"
-	INNER_PATCH_SAVE LANGUAGE_BG2 ~%LANGUAGE_BG2%~ BEGIN
-		REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
-			TO_UPPER MATCH1
-		END ~%MATCH1%~
+	COUNT_2DA_ROWS 3 weidu_conf_rows
+	FOR (weidu_conf_row=0; weidu_conf_row < weidu_conf_rows; ++weidu_conf_row) BEGIN
+		READ_2DA_ENTRY weidu_conf_row 0 3 weidu_conf_param
+		PATCH_IF ~%weidu_conf_param%~ STR_EQ ~lang_dir~ BEGIN
+			READ_2DA_ENTRY weidu_conf_row 2 3 "LANGUAGE_BG2"
+			INNER_PATCH_SAVE LANGUAGE_BG2 ~%LANGUAGE_BG2%~ BEGIN
+				REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
+					TO_UPPER MATCH1
+				END ~%MATCH1%~
+			END
+		END
 	END
 	PATCH_PRINT ~LANGUAGE_BG2 = %LANGUAGE_BG2%~
 

--- a/EET/lib/bgee_dir.tph
+++ b/EET/lib/bgee_dir.tph
@@ -133,18 +133,15 @@ COPY + ~.../bgee_dir.txt~ ~%MOD_FOLDER%/bgee_dir.txt~ EVALUATE_BUFFER
 
 ACTION_IF FILE_EXISTS ~%bgee_dir%/weidu.conf~ BEGIN
 	COPY - ~%bgee_dir%/weidu.conf~ ~.../%bgee_dir%~
-		COUNT_2DA_ROWS 3 weidu_conf_rows
-		FOR (weidu_conf_row=0; weidu_conf_row < weidu_conf_rows; ++weidu_conf_row) BEGIN
-			READ_2DA_ENTRY weidu_conf_row 0 3 weidu_conf_param
-			PATCH_IF ~%weidu_conf_param%~ STR_EQ ~lang_dir~ BEGIN
-				READ_2DA_ENTRY weidu_conf_row 2 3 "LANGUAGE_BG1"
-				INNER_PATCH_SAVE LANGUAGE_BG1 ~%LANGUAGE_BG1%~ BEGIN
-					REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
-						TO_UPPER MATCH1
-					END ~%MATCH1%~
-				END
-			END
+		REPLACE_EVALUATE ~\blang_dir[ %TAB%]*=[ %TAB%]*\([a-zA-Z0-9_]+\)~ BEGIN
+	    	SPRINT LANGUAGE_BG1 ~%MATCH1%~
+	  	END ~%MATCH0%~
+		INNER_PATCH_SAVE LANGUAGE_BG1 ~%LANGUAGE_BG1%~ BEGIN
+			REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
+				TO_UPPER MATCH1
+			END ~%MATCH1%~
 		END
+	BUT_ONLY
 END ELSE ACTION_IF FILE_EXISTS ~%bgee_dir%/lang/%LANGUAGE%/dialog.tlk~ BEGIN
 	OUTER_SPRINT LANGUAGE_BG1 ~%LANGUAGE%~
 END ELSE ACTION_IF FILE_EXISTS ~%bgee_dir%/lang/%LANGUAGE_BG2%/dialog.tlk~ BEGIN

--- a/EET/lib/bgee_dir.tph
+++ b/EET/lib/bgee_dir.tph
@@ -133,11 +133,17 @@ COPY + ~.../bgee_dir.txt~ ~%MOD_FOLDER%/bgee_dir.txt~ EVALUATE_BUFFER
 
 ACTION_IF FILE_EXISTS ~%bgee_dir%/weidu.conf~ BEGIN
 	COPY - ~%bgee_dir%/weidu.conf~ ~.../%bgee_dir%~
-		READ_2DA_ENTRY 0 2 3 "LANGUAGE_BG1"
-		INNER_PATCH_SAVE LANGUAGE_BG1 ~%LANGUAGE_BG1%~ BEGIN
-			REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
-				TO_UPPER MATCH1
-			END ~%MATCH1%~
+		COUNT_2DA_ROWS 3 weidu_conf_rows
+		FOR (weidu_conf_row=0; weidu_conf_row < weidu_conf_rows; ++weidu_conf_row) BEGIN
+			READ_2DA_ENTRY weidu_conf_row 0 3 weidu_conf_param
+			PATCH_IF ~%weidu_conf_param%~ STR_EQ ~lang_dir~ BEGIN
+				READ_2DA_ENTRY weidu_conf_row 2 3 "LANGUAGE_BG1"
+				INNER_PATCH_SAVE LANGUAGE_BG1 ~%LANGUAGE_BG1%~ BEGIN
+					REPLACE_EVALUATE CASE_INSENSITIVE ~\(..\)$~ BEGIN
+						TO_UPPER MATCH1
+					END ~%MATCH1%~
+				END
+			END
 		END
 END ELSE ACTION_IF FILE_EXISTS ~%bgee_dir%/lang/%LANGUAGE%/dialog.tlk~ BEGIN
 	OUTER_SPRINT LANGUAGE_BG1 ~%LANGUAGE%~


### PR DESCRIPTION
Since 2.6, BG needs an x64 environment, so the memory constraints for x86 WeiDU shouldn't apply.

Special thanks to @Argent77 for explaining how to use `REPLACE_EVALUATE` for lookups.

Split from #189.