### PR TITLE
WeiDU 251 compatibility fix

### DIFF
--- a/EET/EET.tp2
+++ b/EET/EET.tp2
@@ -229,13 +229,13 @@ END
 OUTER_SET cd_eefp_bgee = 0
 ACTION_IF FILE_EXISTS ~%bgee_dir%/WeiDU.log~ BEGIN
 	COPY + ~%bgee_dir%/WeiDU.log~ ~%MOD_FOLDER%/temp~
-    COUNT_REGEXP_INSTANCES "^~EEFIXPACK/SETUP-EEFIXPACK\.TP2~ #[0-9]+ #0" cd_eefp_bgee
+    COUNT_REGEXP_INSTANCES "^~EEFIXPACK[/\\]SETUP-EEFIXPACK\.TP2~ #[0-9]+ #0" cd_eefp_bgee
 		REPLACE_TEXTUALLY ~^//.*~ ~~ //removes "Recently uninstalled" lines
-		COUNT_REGEXP_INSTANCES "^~SOA/SETUP-SOA\.TP2~ #[0-9]+ #1 " num_matches
+		COUNT_REGEXP_INSTANCES "^~SOA[/\\]SETUP-SOA\.TP2~ #[0-9]+ #1 " num_matches
 		PATCH_IF (num_matches > 0) BEGIN
 			PATCH_FAIL @900006 //You've installed wrong The Stone of Askavar component. EET is compatible with Default version (option 1 during installation).
 		END
-		COUNT_REGEXP_INSTANCES "^~DRIZZTSAGA/DRIZZTSAGA\.TP2~ #[0-9]+ #1 " num_matches
+		COUNT_REGEXP_INSTANCES "^~DRIZZTSAGA[/\\]DRIZZTSAGA\.TP2~ #[0-9]+ #1 " num_matches
 		PATCH_IF (num_matches > 0) BEGIN
 			PATCH_FAIL @900007 //You've installed wrong Drizzt Saga component. EET is compatible with Default version (option 1 during installation).
 		END


### PR DESCRIPTION
WeiDU 251 changed path definitions in the WeiDU.log on Windows systems by using backslashes instead of slashes as path separators. This fix includes backslashes in the regexp patterns that are used for scanning WeiDU.log entries.